### PR TITLE
Remove trailing spaces middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-command-mapper",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-command-mapper",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-command-mapper",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-command-mapper",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Helps with mapping tools and commands to hubot",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "npm run mocha --recursive test/**/*.spec.ts --exit",
+    "test": "del-cli dist & npm run mocha --recursive test/**/*.spec.ts --exit",
     "mocha": "mocha -r ts-node/register",
     "build": "del-cli dist & tsc",
     "prepublishOnly": "npm run build & npm test & npm version patch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-command-mapper",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Helps with mapping tools and commands to hubot",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-command-mapper",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Helps with mapping tools and commands to hubot",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/definitions/Hubot.d.ts
+++ b/src/definitions/Hubot.d.ts
@@ -53,6 +53,7 @@ declare namespace Hubot {
       receiveMiddleware(receiveMiddlewareCallback): void;
 
       __tools? : IMutable[];
+      __switches? : string[];
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { RegExStringParameter } from "./entities/parameters/RegExStringParameter
 import { TokenParameter } from "./entities/parameters/TokenParameter";
 import { IPv4Parameter } from "./entities/parameters/IPv4Parameter";
 import { IContext } from "mocha";
+import { removeTrailingWhitespaceCharactersFromIncommingMessages } from "./middleware/removeTrailingWhitespaceCharactersFromIncommingMessages";
 
 export {
   IParameter,
@@ -35,7 +36,8 @@ export {
   ITool, 
   ICommand,
   ICallback,
-  IContext
+  IContext,
+  removeTrailingWhitespaceCharactersFromIncommingMessages
 }
 
 //needed for reload - otherwise the caller value will be cached

--- a/src/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.ts
+++ b/src/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.ts
@@ -1,0 +1,34 @@
+import { IOptions, defaultOptions } from "..";
+import { hasSwitch, setSwitch } from "../utils/switches";
+
+const FIX_TRAILING_SPACES_SWITCH = 'ftss';
+
+export function removeTrailingWhitespaceCharactersFromIncommingMessages(
+    robot: Hubot.Robot,
+    options: IOptions = defaultOptions
+  ) {
+  
+    if (!robot) throw "Argument 'robot' is empty.";
+
+    if(hasSwitch(robot, FIX_TRAILING_SPACES_SWITCH)){
+      if(options.verbose)
+        console.log("The fix trailing spaces middleware has already been registered.");
+
+        return;
+    }
+
+    setSwitch(robot, FIX_TRAILING_SPACES_SWITCH);
+
+    robot.receiveMiddleware((context, next, done) => {
+  
+      var text = context.response.message.text;
+      var newText = text.replace(/\s+$/, '');
+  
+      if (text != newText) {
+        context.response.message.text = newText;
+      }
+  
+      next(done);
+    });
+  }
+  

--- a/src/utils/switches.ts
+++ b/src/utils/switches.ts
@@ -1,0 +1,16 @@
+export function hasSwitch(robot: Hubot.Robot, name: string){
+    if(!robot.__switches)
+        return false;
+    return robot.__switches.indexOf(name) != -1;
+}
+
+export function setSwitch(robot: Hubot.Robot, name: string){
+
+    if(hasSwitch(robot, name))
+        return;
+
+    if(!robot.__switches)
+        robot.__switches = [];
+
+    robot.__switches.push(name);
+}

--- a/test/alias.spec.ts
+++ b/test/alias.spec.ts
@@ -12,7 +12,7 @@ describe("alias.spec.ts / Testing the alias features", () => {
     var options = new Options();
     options.verbose = false;
 
-    map_command(pretend.robot, "version", (context) => context.res.reply("1"));
+    map_command(pretend.robot, "version", options, (context) => context.res.reply("1"));
     alias(pretend.robot, { AAA: "version" }, options);
 
     mapper(

--- a/test/issues/3.spec.ts
+++ b/test/issues/3.spec.ts
@@ -28,7 +28,6 @@ describe("issues / 3.spec.ts / Testing problems with robot not responding to ali
       .user("kees")
       .send("@aliasbot ping")
       .then(() => {
-        console.log(pretend.messages);
         expect(pretend.messages).to.eql([
           ["kees", "@aliasbot ping"],
           ["hubot", "@kees pong"]

--- a/test/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts
+++ b/test/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts
@@ -28,7 +28,7 @@ describe("removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts / trai
 
     afterEach(() => pretend.shutdown());
 
-    it.only("Trailing spaces should be removed", done => {
+    it("Trailing spaces should be removed", done => {
         pretend
             .user("kees")
             .send("@hubot ping this is a test with spaces     ")
@@ -40,7 +40,7 @@ describe("removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts / trai
             .catch(ex => done(ex));
     });
     
-    it.only("Trailing tabs should be removed", done => {
+    it("Trailing tabs should be removed", done => {
         pretend
             .user("kees")
             .send("@hubot ping this is a test with tabs           ")
@@ -52,7 +52,7 @@ describe("removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts / trai
             .catch(ex => done(ex));
     });
     
-    it.only("Trailing enters should be removed", done => {
+    it("Trailing enters should be removed", done => {
         pretend
             .user("kees")
             .send(`@hubot ping this is a test with enters

--- a/test/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts
+++ b/test/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts
@@ -1,0 +1,69 @@
+const pretend = require("hubot-pretend");
+import { expect } from "chai";
+import "mocha";
+import { map_command, Options } from "../../dist";
+import { RestParameter, removeTrailingWhitespaceCharactersFromIncommingMessages } from "../../src";
+
+describe("removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts / trailing spaces fixer", () => {
+
+    const SWITCH = "SOME_SWITCH_NAME";
+
+    beforeEach(() => {
+        pretend.start();
+        var options = new Options();
+        options.verbose = false;
+
+        // map dummy command
+        map_command(
+            pretend.robot,
+            'ping',
+            new RestParameter("rest"),
+            options,
+            (context) => context.res.reply(`Got this: "${context.values.rest}"`)
+        );
+
+        // map the trailing space fixer
+        removeTrailingWhitespaceCharactersFromIncommingMessages(pretend.robot, options);
+    });
+
+    afterEach(() => pretend.shutdown());
+
+    it.only("Trailing spaces should be removed", done => {
+        pretend
+            .user("kees")
+            .send("@hubot ping this is a test with spaces     ")
+            .then(() => {
+                var message = pretend.messages[1][1];
+                expect(message).to.eq('@kees Got this: "this is a test with spaces"');
+                done();
+            })
+            .catch(ex => done(ex));
+    });
+    
+    it.only("Trailing tabs should be removed", done => {
+        pretend
+            .user("kees")
+            .send("@hubot ping this is a test with tabs           ")
+            .then(() => {
+                var message = pretend.messages[1][1];
+                expect(message).to.eq('@kees Got this: "this is a test with tabs"');
+                done();
+            })
+            .catch(ex => done(ex));
+    });
+    
+    it.only("Trailing enters should be removed", done => {
+        pretend
+            .user("kees")
+            .send(`@hubot ping this is a test with enters
+
+`)
+            .then(() => {
+                var message = pretend.messages[1][1];
+                expect(message).to.eq('@kees Got this: "this is a test with enters"');
+                done();
+            })
+            .catch(ex => done(ex));
+    });
+
+});

--- a/test/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts
+++ b/test/middleware/removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts
@@ -1,8 +1,7 @@
 const pretend = require("hubot-pretend");
 import { expect } from "chai";
 import "mocha";
-import { map_command, Options } from "../../dist";
-import { RestParameter, removeTrailingWhitespaceCharactersFromIncommingMessages } from "../../src";
+import { map_command, Options, RestParameter, removeTrailingWhitespaceCharactersFromIncommingMessages } from "../../src";
 
 describe("removeTrailingWhitespaceCharactersFromIncommingMessages.spec.ts / trailing spaces fixer", () => {
 

--- a/test/utils/switches.spec.ts
+++ b/test/utils/switches.spec.ts
@@ -1,0 +1,27 @@
+const pretend = require("hubot-pretend");
+import { expect } from "chai";
+import "mocha";
+import { hasSwitch, setSwitch } from '../../src/utils/switches';
+
+describe("switches.spec.ts / switches", () => {
+
+  const SWITCH = "SOME_SWITCH_NAME";
+
+  beforeEach(() => {
+    pretend.start();
+  });
+
+  afterEach(() => pretend.shutdown());
+
+  it("No parameters set should return false.", done => {
+    expect(hasSwitch(pretend.robot, SWITCH)).to.eql(false);
+    done();
+  });
+
+  it("Setting a parameter should return true.", done => {
+    setSwitch(pretend.robot, SWITCH);
+    expect(hasSwitch(pretend.robot, SWITCH)).to.eql(true);
+    done();
+  });
+
+});


### PR DESCRIPTION
Added middleware that can remove trailing spaces of messages. This is very handy when you have users with mobile keyboard that add trailing spaces. This might some commands from not working.